### PR TITLE
Remove unicode_literal import to silence click warning

### DIFF
--- a/keg/_flask_cli.py
+++ b/keg/_flask_cli.py
@@ -9,7 +9,6 @@
     :license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import os
 import sys

--- a/keg/app.py
+++ b/keg/app.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import warnings
 

--- a/keg/assets.py
+++ b/keg/assets.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from collections import defaultdict
 import pathlib

--- a/keg/blueprints/__init__.py
+++ b/keg/blueprints/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import flask
 

--- a/keg/cli.py
+++ b/keg/cli.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from collections import defaultdict
 import platform

--- a/keg/compat.py
+++ b/keg/compat.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import six
 

--- a/keg/config.py
+++ b/keg/config.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import os.path as osp
 

--- a/keg/ctx.py
+++ b/keg/ctx.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from flask.ctx import RequestContext
 from keg.assets import AssetManager

--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from flask.ext.sqlalchemy import SQLAlchemy
 

--- a/keg/db/dialect_ops.py
+++ b/keg/db/dialect_ops.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from sqlalchemy import MetaData
 

--- a/keg/keyring.py
+++ b/keg/keyring.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import getpass
 import re

--- a/keg/logging.py
+++ b/keg/logging.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import logging
 from logging.handlers import RotatingFileHandler

--- a/keg/oauth/__init__.py
+++ b/keg/oauth/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from flask import url_for, session, request, jsonify, Blueprint, flash, current_app
 from flask_oauthlib.client import OAuth

--- a/keg/oauth/google.py
+++ b/keg/oauth/google.py
@@ -1,2 +1,1 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals

--- a/keg/signals.py
+++ b/keg/signals.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from flask.signals import Namespace
 

--- a/keg/templating.py
+++ b/keg/templating.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from flask.globals import _request_ctx_stack
 

--- a/keg/testing.py
+++ b/keg/testing.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import click
 import click.testing

--- a/keg/tests/test_app.py
+++ b/keg/tests/test_app.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from blazeutils.testing import raises
 

--- a/keg/tests/test_assets.py
+++ b/keg/tests/test_assets.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import os
 

--- a/keg/tests/test_cli.py
+++ b/keg/tests/test_cli.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import mock
 import pytest

--- a/keg/tests/test_config.py
+++ b/keg/tests/test_config.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import os
 

--- a/keg/tests/test_db.py
+++ b/keg/tests/test_db.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import pytest
 

--- a/keg/tests/test_db_dialects.py
+++ b/keg/tests/test_db_dialects.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import pytest
 

--- a/keg/tests/test_logging.py
+++ b/keg/tests/test_logging.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import pathlib
 

--- a/keg/tests/test_templating.py
+++ b/keg/tests/test_templating.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from jinja2 import TemplateSyntaxError
 import pytest

--- a/keg/tests/test_utils.py
+++ b/keg/tests/test_utils.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import tempfile
 

--- a/keg/tests/test_view_routing.py
+++ b/keg/tests/test_view_routing.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 from keg.testing import WebBase
 
 from keg_apps.web.app import WebApp

--- a/keg/tests/test_view_templating.py
+++ b/keg/tests/test_view_templating.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 from keg.testing import WebBase
 
 from keg_apps.web.app import WebApp

--- a/keg/tests/test_web.py
+++ b/keg/tests/test_web.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from keg.testing import WebBase
 

--- a/keg/utils.py
+++ b/keg/utils.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import os
 import sys

--- a/keg/version.py
+++ b/keg/version.py
@@ -1,3 +1,1 @@
-from __future__ import unicode_literals
-
 VERSION = '0.3.0'

--- a/keg/web.py
+++ b/keg/web.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import inspect
 import sys


### PR DESCRIPTION
- Click pukes a nasty warning when it finds an import unicode_literals
  in a source file.

See: http://click.pocoo.org/5/python3/#unicode-literals
