### PR TITLE
Config and route improvements

### DIFF
--- a/keg/signals.py
+++ b/keg/signals.py
@@ -6,9 +6,14 @@ _signals = Namespace()
 
 # Call when application initializations is completed.
 # Sender will be the application instance.
+init_complete = _signals.signal('init-complete')
+# Will deprecate app-ready eventually
 app_ready = _signals.signal('app-ready')
 
+# Same signals.  Will deprecate config_ready eventually.
 config_ready = _signals.signal('config-ready')
+config_complete = _signals.signal('config-complete')
+
 testing_run_start = _signals.signal('testing-run-start')
 
 db_clear_pre = _signals.signal('db-clear-pre')

--- a/keg/testing.py
+++ b/keg/testing.py
@@ -28,10 +28,10 @@ class ContextManager(object):
         self.app = None
         self.ctx = None
 
-    def ensure_current(self):
+    def ensure_current(self, config):
 
         if not self.app:
-            self.app = self.appcls().init(use_test_profile=True)
+            self.app = self.appcls().init(use_test_profile=True, config=config)
             self.ctx = self.app.app_context()
             self.ctx.push()
 
@@ -103,6 +103,5 @@ class WebBase(object):
 
     @classmethod
     def setup_class(cls):
-        cls.appcls.testing_prep()
-        cls.app = flask.current_app
+        cls.app = cls.appcls.testing_prep()
         cls.testapp = TestApp(flask.current_app)

--- a/keg/tests/test_app.py
+++ b/keg/tests/test_app.py
@@ -12,3 +12,27 @@ class TestInit(object):
         app = Keg(__name__)
         app.init(use_test_profile=True)
         app.init(use_test_profile=True)
+
+
+class TestRouteDecorator(object):
+    class TRDApp(Keg):
+        import_name = __name__ + ':TRDApp'
+
+    class TRDApp2(Keg):
+        import_name = __name__ + ':TRDApp2'
+
+    def test_class_method(self):
+        @self.TRDApp.route('/foo')
+        def foo():
+            pass
+
+        @self.TRDApp.route('/bar')
+        def bar():
+            pass
+
+        @self.TRDApp2.route('/baz')
+        def baz():
+            pass
+
+        assert len(self.TRDApp._routes) == 2
+        assert len(self.TRDApp2._routes) == 1

--- a/keg/tests/test_config.py
+++ b/keg/tests/test_config.py
@@ -19,6 +19,18 @@ class TestConfigDefaults(object):
         # this key comes from Keg's DefaultProfile
         assert 'KEG_ENDPOINTS' in app.config
 
+    def test_init_configs(self):
+        app = Keg(__name__, config={'ABC': 123}).init()
+        assert app.config['ABC'] == 123
+
+        app = Keg(__name__).init(config={'ABC': 123})
+        assert app.config['ABC'] == 123
+
+        class TestingPrepConfigApp(Keg):
+            import_name = __name__
+        app = TestingPrepConfigApp.testing_prep(ABC=123)
+        assert app.config['ABC'] == 123
+
     def test_app_params_profile(self):
         app = Keg(__name__).init(config_profile='Foo', use_test_profile=True)
         assert app.config.profile == 'Foo'

--- a/keg/tests/test_view_routing.py
+++ b/keg/tests/test_view_routing.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from keg.testing import WebBase
 
 from keg_apps.web.app import WebApp
@@ -255,3 +256,16 @@ class TestViewRouting(WebBase):
 
         resp = self.testapp.get('/planes/list')
         assert resp.text == 'listing Planes'
+
+    def test_routing_decorator_class_context(self):
+        self.testapp.get('/simple', status=200)
+
+        # Make sure options dict gets passed through correctly by making sure we can POST.
+        self.testapp.post('/simple', status=200)
+
+        # make sure the endpoints got set correctly
+        assert self.app.view_functions['simple1']
+        assert self.app.view_functions['simple2']
+
+    def test_routing_decorator_instance_context(self):
+        self.testapp.get('/simple3', status=200)

--- a/keg/utils.py
+++ b/keg/utils.py
@@ -53,6 +53,45 @@ class ClassProperty(property):
 classproperty = ClassProperty
 
 
+class HybridMethod(object):
+    """
+        A decorator which allows definition of a Python object method with both
+        instance-level and class-level behavior:
+
+            Class Bar:
+
+                @hybridmethod
+                def foo(self, rule, **options):
+                    # this is used in an instance context
+
+                @foo.classmethod
+                def foo(cls, rule, **options):
+                    # this is used in class context
+
+    """
+
+    def __init__(self, func, cm_func=None):
+        self.instance_func = func
+        self.classmethod(cm_func or func)
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self.cm_func.__get__(owner, owner.__class__)
+        else:
+            return self.instance_func.__get__(instance, owner)
+
+    def classmethod(self, cm_func):
+        """Provide a modifying decorator that is used as a classmethod decorator."""
+
+        self.cm_func = cm_func
+        if not self.cm_func.__doc__:
+            self.cm_func.__doc__ = self.instance_func.__doc__
+        return self
+
+
+hybridmethod = HybridMethod
+
+
 def pymodule_fpaths_to_objects(fpaths):
     """
         Takes an iterable of file paths reprenting possible python modules and will return an

--- a/keg_apps/web/app.py
+++ b/keg_apps/web/app.py
@@ -19,3 +19,20 @@ class WebApp(Keg):
 
     template_filters = {'addkeg': addkeg}
     template_globals = {'sayfoo': sayfoo}
+
+    def on_init_complete(self):
+        # Using .route() in an instance context
+        @self.route('/simple3')
+        def simple3():
+            return 'simple3'
+
+
+# Using .route() in a class context
+@WebApp.route('/simple', endpoint='simple1', methods=['GET', 'POST'])
+def simple():
+    return 'simple'
+
+
+@WebApp.route('/simple2', methods=['GET', 'POST'])
+def simple2():
+    return 'simple2'


### PR DESCRIPTION
* Misc fixes
* Config & init adjustments
  * Add signals `config_complete` and `init_complete`, they do the same thing as signals `config_ready` and `app_ready` I just like the new naming scheme better.
  * Add Keg.on_config_complete() and Keg.on_init_complete() methods to match the signals just added.  They are intended to be used by sub-classes to give them an easy way to tie into events without needing to use signals.
  * Add ability to pass config arguments through the constructor and `Keg.init()` and `Keg.testing_prep()`.
* Add Keg.routing() for easier addition of non-class view functions to a Keg app.