### PR TITLE
fix quiet logging

### DIFF
--- a/keg/cli.py
+++ b/keg/cli.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from collections import defaultdict
-import logging
 import platform
 
 import click
@@ -339,7 +338,7 @@ class CLILoader(object):
         """
         retval = dict(config_profile=cli_options.get('profile', None), config={})
         if cli_options.get('quiet', False):
-            retval['config']['KEG_LOG_LEVEL'] = logging.WARN
+            retval['config']['KEG_LOG_STREAM_ENABLED'] = False
         return retval
 
     def create_script_options(self):

--- a/keg/tests/test_cli.py
+++ b/keg/tests/test_cli.py
@@ -60,8 +60,13 @@ class TestCLI2(CLIBase):
 
     def test_quiet(self):
         # the asserts for these tests are in keg_apps.cli2.cli
-        self.invoke('--quiet', 'is_quiet')
-        self.invoke('is_not_quiet')
+        result = self.invoke('--quiet', 'is_quiet')
+        assert 'printed foo' in result.output
+        assert 'logged foo' not in result.output
+
+        result = self.invoke('is_not_quiet')
+        assert 'printed foo' in result.output
+        assert 'logged foo' in result.output
 
 
 class TestConfigCommand(CLIBase):

--- a/keg_apps/cli2/cli.py
+++ b/keg_apps/cli2/cli.py
@@ -1,9 +1,10 @@
 import logging
 
 import click
-import flask
 
 from .app import CLI2App
+
+log = logging.getLogger(__name__)
 
 
 @CLI2App.cli.command('hello1')
@@ -13,9 +14,11 @@ def hello1():
 
 @CLI2App.cli.command()
 def is_quiet():
-    assert flask.current_app.logging.logging_level == logging.WARN
+    print('printed foo')
+    log.info('logged foo')
 
 
 @CLI2App.cli.command()
 def is_not_quiet():
-    assert flask.current_app.logging.logging_level == logging.INFO
+    print('printed foo')
+    log.info('logged foo')


### PR DESCRIPTION
I was setting the log level, but that was affecting all logging handlers including syslog handlers.  So we weren't getting INFO messages in the logs when we enabled `--quiet`.  The correct solution is to not log to STDOUT when quiet is enabled.