### PR TITLE
db: get rid of code to replace session object

### DIFF
--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -1,26 +1,12 @@
 from __future__ import absolute_import
 
-from flask_sqlalchemy import SQLAlchemy
+import flask_sqlalchemy as fsa
 
 from keg.signals import testing_run_start, db_init_pre, db_init_post, db_clear_pre, db_clear_post
 from keg.utils import visit_modules
 
 
-class KegSQLAlchemy(SQLAlchemy):
-
-    def init_app(self, app):
-        SQLAlchemy.init_app(self, app)
-        if app.testing:
-            self.testing_scoped_session()
-
-    def testing_scoped_session(self):
-        # don't want to have to import this if we are in production, so put import
-        # inside of the method
-        from flask_webtest import get_scopefunc
-
-        # flask-sqlalchemy creates the session when the class is initialized.  We have to re-create
-        # with different session options and override the session attribute with the new session
-        db.session = db.create_scoped_session(options={'scopefunc': get_scopefunc()})
+class KegSQLAlchemy(fsa.SQLAlchemy):
 
     def get_engines(self, app):
         # the default engine doesn't have a bind

--- a/keg/tests/test_db.py
+++ b/keg/tests/test_db.py
@@ -5,6 +5,7 @@ import pytest
 from keg import current_app
 from keg.db import db
 from keg.signals import db_init_pre, db_init_post, db_clear_post, db_clear_pre
+from keg.testing import invoke_command
 
 import keg_apps.db.model.entities as ents
 from keg_apps.db.app import DBApp
@@ -102,3 +103,13 @@ class TestDatabaseManager(object):
         assert self.init_post_connected
         assert self.clear_pre_connected
         assert self.clear_post_connected
+
+
+class TestKegSQLAlchemy(object):
+    def test_session_ids_with_cli_invocation(self):
+        sess_id = id(db.session)
+
+        result = invoke_command(DBApp, 'hello')
+        assert 'hello db cli' in result.output
+
+        assert id(db.session) == sess_id

--- a/keg_apps/db/app.py
+++ b/keg_apps/db/app.py
@@ -8,5 +8,10 @@ class DBApp(Keg):
     db_enabled = True
 
 
+@DBApp.cli.command()
+def hello():
+    print('hello db cli')
+
+
 if __name__ == '__main__':
     DBApp.cli.main()


### PR DESCRIPTION
This was causing a new session object to be created anytime a new app was initialized which would leave existing sessions and transactions open with no discernible way to close them (until GC runs I believe).

I'm not sure why this code was here in the first place but it doesn't seem to add any value.  If you want split scope sessions, you can easily do that with Flask-WebTest.