### PR TITLE
when testing, don't log to syslog by default

### DIFF
--- a/keg/config.py
+++ b/keg/config.py
@@ -186,6 +186,7 @@ class TestProfile(object):
     DEBUG = True
     TESTING = True
     KEG_KEYRING_ENABLE = False
+    KEG_LOG_SYSLOG_ENABLED = False
 
     # set this to allow generation of URLs without a request context
     SERVER_NAME = 'keg.example.com' if six.PY3 else b'keg.example.com'

--- a/keg/tests/test_logging.py
+++ b/keg/tests/test_logging.py
@@ -41,7 +41,7 @@ class TestLogging(object):
 
     def test_syslog_handler(self):
         with mock.patch('keg.logging.SysLogHandler.emit') as m_emit:
-            LoggingApp().init(use_test_profile=True)
+            LoggingApp().init(use_test_profile=True, config={'KEG_LOG_SYSLOG_ENABLED': True})
             log.warning('test warn log')
             log.info('test info log')
 


### PR DESCRIPTION
No reason to clutter syslog with such messages