### PR TITLE
Add KEG_DB_ENGINE_OPTIONS Configuration

### DIFF
--- a/keg/config.py
+++ b/keg/config.py
@@ -176,6 +176,7 @@ class DefaultProfile(object):
     KEG_SMTP_HOST = 'localhost'
 
     KEG_DB_DIALECT_OPTIONS = {}
+    KEG_DB_ENGINE_OPTIONS = {}
 
 
 class DevProfile(object):

--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -8,6 +8,19 @@ from keg.utils import visit_modules
 
 class KegSQLAlchemy(fsa.SQLAlchemy):
 
+    def apply_driver_hacks(self, app, info, options):
+        """Override some driver specific settings"""
+        super().apply_driver_hacks(app, info, options)
+
+        engine_opts = app.config.get('KEG_DB_ENGINE_OPTIONS', {})
+
+        # Turn on SA pessimistic disconnect handling by default:
+        # http://docs.sqlalchemy.org/en/latest/core/pooling.html#disconnect-handling-pessimistic
+        engine_opts.setdefault('pool_pre_ping', True)
+
+        if engine_opts:
+            options.update(engine_opts)
+
     def get_engines(self, app):
         # the default engine doesn't have a bind
         retval = [(None, self.get_engine(app))]

--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -18,8 +18,8 @@ class KegSQLAlchemy(fsa.SQLAlchemy):
         # http://docs.sqlalchemy.org/en/latest/core/pooling.html#disconnect-handling-pessimistic
         engine_opts.setdefault('pool_pre_ping', True)
 
-        if engine_opts:
-            options.update(engine_opts)
+        # Update the options with the engine options we received from the application
+        options.update(engine_opts)
 
     def get_engines(self, app):
         # the default engine doesn't have a bind

--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -10,7 +10,7 @@ class KegSQLAlchemy(fsa.SQLAlchemy):
 
     def apply_driver_hacks(self, app, info, options):
         """Override some driver specific settings"""
-        super().apply_driver_hacks(app, info, options)
+        super(KegSQLAlchemy, self).apply_driver_hacks(app, info, options)
 
         engine_opts = app.config.get('KEG_DB_ENGINE_OPTIONS', {})
 

--- a/readme.rst
+++ b/readme.rst
@@ -159,3 +159,16 @@ Current Status
 * Stable in a relatively small number of production environments.
 * API is likely to change with smaller compatibility breaks happening more frequently than larger ones.
 
+
+Configuration Variables
+-----------------------
+
+This is not an exhaustive list of `KEG_` specific configuration variables:
+
+- ``KEG_DB_ENGINE_OPTIONS``: Add additional engine options to the
+  ``sqlalchemy.create_engine`` call when working with a database. ::
+
+      KEG_DB_ENGINE_OPTIONS = {
+          'json_serializer': flask.json.dumps,
+          'json_deserializer': flask.json.loads,
+      }


### PR DESCRIPTION
#59 should be done at some point, however I didn't have time for it right now.'

This removes [all of this from the cookie cutter](https://github.com/level12/keg-app-cookiecutter/blob/master/%7B%7Bcookiecutter.project_dashed%7D%7D-src/%7B%7Bcookiecutter.project_namespace%7D%7D/app.py#L42-L71)