### PR TITLE
Testing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 tags
 .vscode
 .pytest_cache
+keg_apps/keg_apps.db-config.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,20 +9,11 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    # Pre-installed Python versions, which Appveyor may upgrade to
-    # a later point release.
-    - PYTHON: "C:\\Python27"
-      TOXENV: py27-{base,lowest,i18n}
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: '3.5'
-      TOXENV: py35
-
     - PYTHON: "C:\\Python36"
-      TOXENV: py36
+      TOXENV: py36,py36-{lowest,i18n}
 
     - PYTHON: "C:\\Python37"
-      TOXENV: py37-{base,lowest,i18n}
+      TOXENV: py37,py37-{lowest,i18n}
 
   INSTANCENAME: "SQL2008R2SP2"
   PGUSER: postgres
@@ -50,7 +41,7 @@ install:
 
   # Install everything needed for tests that tox doesn't install
   - python -m pip install --upgrade pip
-  - python -m pip install --upgrade virtualenv tox wheel codecov pymssql
+  - python -m pip install --upgrade virtualenv tox wheel codecov pyodbc sqlalchemy-pyodbc-mssql
 
 build: off
 

--- a/keg/tests/test_app.py
+++ b/keg/tests/test_app.py
@@ -1,17 +1,17 @@
 from __future__ import absolute_import
 
-from blazeutils.testing import raises
+import pytest
 
 from keg.app import Keg, KegAppError
 
 
 class TestInit(object):
 
-    @raises(KegAppError, 'init() already called')
     def test_init_called_twice_error(self):
-        app = Keg(__name__)
-        app.init(use_test_profile=True)
-        app.init(use_test_profile=True)
+        with pytest.raises(KegAppError, match=r'init\(\) already called on this instance'):
+            app = Keg(__name__)
+            app.init(use_test_profile=True)
+            app.init(use_test_profile=True)
 
 
 class TestRouteDecorator(object):

--- a/keg_apps/db/user-config-tpl-appveyor.py
+++ b/keg_apps/db/user-config-tpl-appveyor.py
@@ -5,6 +5,7 @@ class TestProfile(object):
     SQLALCHEMY_BINDS = {
         # Change the postgres database connection to a database dedicated to Keg tests.
         'postgres': 'postgresql://postgres:Password12!@localhost/keg_test',
-        'mssql': 'mssql+pymssql://sa:Password12!@localhost:1433/tempdb',
+        'mssql': 'mssql+pyodbc_mssql://sa:Password12!@localhost:1433/tempdb'
+        '?driver=SQL+Server+Native+Client+11.0',
         'sqlite2': 'sqlite:///'
     }

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             'flask-webtest',
             'flask-wtf',
             'keyring',
-            "pymssql; sys_platform == 'win32'",
+            "sqlalchemy_pyodbc_mssql; sys_platform == 'win32'",
             'pytest',
             'pytest-cov',
             'psycopg2-binary',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'BlazeUtils',
         'blinker',
         'Click>=3.0',
-        'Flask',
+        'Flask<1.1.0',
         'Flask-SQLAlchemy',
         'pathlib',
         'python-json-logger',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
-envlist = py{27,35,36,37},py27-{lowest,i18n},py37-{lowest,i18n},project
+envlist = py{36,37,38},py36-{lowest,i18n},py38-{lowest,i18n},project
 
 
 [testenv]
+setenv =
+    PIP_EXTRA_INDEX_URL=https://package-index.level12.net
 # Ignore all "not installed in testenv" warnings.
 whitelist_externals = *
 skip_install = true


### PR DESCRIPTION
- update tox and appveyor config for what's available testing images
- switch pymssql to pyodbc
- limit flask to <1.1.0, as there appears to be some context breakage there (#90?)

Note, python 3.8 is not yet available in the standard appveyor image.