### PR TITLE
update blueprint support

### DIFF
--- a/keg/tests/test_view_routing.py
+++ b/keg/tests/test_view_routing.py
@@ -72,6 +72,22 @@ class TestViewRouting(WebBase):
         assert rule.methods == {'GET', 'HEAD', 'OPTIONS'}
         assert rule.endpoint == 'routing.explicit-route'
 
+    def test_blueprint_routes(self):
+        self.testapp.get('/blueprint-test', status=404)
+        self.testapp.get('/tanagra/blueprint-test')
+        self.testapp.get('/custom-route', status=404)
+        self.testapp.get('/tanagra/custom-route')
+
+        from keg_apps.web.views import custom
+        assert custom.BlueprintTest.calc_url() == '/tanagra/blueprint-test'
+        assert custom.BlueprintTest.calc_url(use_blueprint=False) == '/blueprint-test'
+        assert custom.BlueprintTest.calc_endpoint() == 'custom.blueprint-test'
+        assert custom.BlueprintTest.calc_endpoint(use_blueprint=False) == 'blueprint-test'
+        assert custom.BlueprintTest2.calc_url() == '/tanagra/custom-route'
+        assert custom.BlueprintTest2.calc_url(use_blueprint=False) == '/custom-route'
+        assert custom.BlueprintTest2.calc_endpoint() == 'custom.blueprint-test2'
+        assert custom.BlueprintTest2.calc_endpoint(use_blueprint=False) == 'blueprint-test2'
+
     def test_hello_world(self):
         resp = self.testapp.get('/hello-world')
         assert resp.text == 'Hello World'

--- a/keg/tests/test_web.py
+++ b/keg/tests/test_web.py
@@ -19,3 +19,14 @@ class TestBaseViewFeatures(WebBase):
         resp = self.testapp.get('/auto-assign-with-response')
         lines = resp.body.splitlines()
         assert lines[0] == b'bar = '
+
+
+class TestBlueprintUsage(WebBase):
+    appcls = WebApp
+
+    def test_blueprint_url_prefix(self):
+        self.testapp.get('/tanagra/blueprint-test')
+
+    def test_blueprint_template_folder(self):
+        resp = self.testapp.get('/tanagra/blueprint-test')
+        assert 'blueprint template found ok' in resp

--- a/keg_apps/web/templates/specific-path/blueprint_test.html
+++ b/keg_apps/web/templates/specific-path/blueprint_test.html
@@ -1,0 +1,1 @@
+blueprint template found ok

--- a/keg_apps/web/views/__init__.py
+++ b/keg_apps/web/views/__init__.py
@@ -1,5 +1,6 @@
 from .routing import blueprint as routing_bp
 from .templating import blueprint as blueprint_bp
 from .other import blueprint as other_bp
+from .custom import blueprint as custom_bp
 
-all_blueprints = [routing_bp, blueprint_bp, other_bp]
+all_blueprints = [routing_bp, blueprint_bp, other_bp, custom_bp]

--- a/keg_apps/web/views/custom.py
+++ b/keg_apps/web/views/custom.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+import flask
+
+from keg.web import BaseView as KegBaseView
+
+blueprint = flask.Blueprint(
+    'custom',
+    __name__,
+    template_folder='../templates/specific-path',
+    url_prefix='/tanagra',
+)
+
+
+class BaseView(KegBaseView):
+    blueprint = blueprint
+
+
+class BlueprintTest(BaseView):
+    def get(self):
+        return self.render()
+
+
+class BlueprintTest2(BaseView):
+    url = '/custom-route'
+
+    def get(self):
+        return self.render()

--- a/readme.rst
+++ b/readme.rst
@@ -120,6 +120,114 @@ A Keg app considers the "selected" profile as follows:
   highest priority.
 
 
+Views
+=====
+
+While generic Flask views will certainly work in this framework, Keg provides a BaseView that
+applies a certain amount of magic around route and blueprint setup. BaseView is based on Flask's
+MethodView. Best practice is to set up a blueprint and attach the views to it via the `blueprint`
+attribute. Be aware, BaseView will set up some route, endpoint, and template location defaults,
+but these can be configured if needed.
+
+Blueprint Setup
+---------------
+
+Adding views to a blueprint is accomplished via the `blueprint` attribute on the view. Note,
+BaseView magic kicks in when the class is created, so assigning the blueprint later on will not
+currently have the desired effect.
+
+    import flask
+    from keg.web import BaseView
+
+    blueprint = flask.Blueprint('routing', __name__)
+
+
+    class VerbRouting(BaseView):
+        blueprint = blueprint
+
+        def get(self):
+            return 'method get'
+
+Once the blueprint is created, you must attach it to the app via the `use_blueprints` app attribute:
+
+    from keg.app import Keg
+    from my_app.views import blueprint
+
+
+    class MyApp(Keg):
+        import_name = 'myapp'
+        use_blueprints = (blueprint, )
+
+Blueprints take some parameters for URL prefix and template path. BaseView will respect these when
+generating URLs and finding templates:
+
+    blueprint = flask.Blueprint(
+        'custom',
+        __name__,
+        template_folder='../templates/specific-path',
+        url_prefix='/tanagra')
+
+    class BlueprintTest(BaseView):
+        # template "blueprint_test.html" will be expected in specific-path
+        # endpoint is custom.blueprint-test
+        # URL is /tanagra/blueprint-test
+        blueprint = blueprint
+
+        def get(self):
+            return self.render()
+
+Template Discovery
+------------------
+
+To avoid requiring the developer to configure all the things, BaseView will attempt to discover the
+correct template for a view, based on the view class name. Generally, this is a camel-case to
+underscore-notation conversion. Blueprint name is included in the path, unless the blueprint has
+its own `template_path` defined.
+
+* `class MyBestView` in blueprint named "public" -> `<app>/templates/public/my_best_view.html`
+* `class View2` in blueprint named "other" with template path "foo" -> `<app>/foo/view2.html`
+
+A view may be given a `template_name` attribute to override the default filename, although the same
+path is used for discovery:
+
+    class TemplateOverride(BaseView):
+        blueprint = blueprint
+        template_name = 'my-special-template.html'
+
+        def get(self):
+            return self.render()
+
+URL and Endpoint Calculation
+----------------------------
+
+BaseView has `calc_url` and `calc_endpoint` class methods which will allow the developer to avoid
+hard-coding those types of values throughout the code. These methods will both produce the full
+URL/endpoint, including the blueprint prefix (if any).
+
+Route Generation
+----------------
+
+BaseView will, by default, create rules for views on their respective blueprints. Generally, this
+is based on the view class name as a camel-case to dash-notation conversion:
+
+* `class MyBestView` in blueprint named "public": `/my-best-view` -> `public.my-best-view`
+* `class View2` in blueprint named "other" with URL prefix "foo": `/foo/view2` -> `other.view2`
+
+Note that BaseView is a MethodView implementation, so methods named `get`, `post`, etc. will be
+respected as the appropriate targets in the request/response cycle.
+
+A view may be given a `url` attribute to override the default:
+
+    class RouteOverride(BaseView):
+        blueprint = blueprint
+        url = '/something-other-than-the-default'
+
+        def get(self):
+            return self.render()
+
+See `keg_apps/web/views/routing.py` for other routing possibilities that BaseView supports.
+
+
 Keg Development
 ===============
 


### PR DESCRIPTION
- respect blueprint template paths
- calc_url and calc_endpoint should generally return the full url or endpoint, including blueprint prefixes
  - the exception to this, of course, is when the routes/blueprint are being initialized
fixes #84