### PR TITLE
introduce a component scheme

### DIFF
--- a/keg/__init__.py
+++ b/keg/__init__.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 
-from flask import current_app
+from flask import current_app  # noqa: F401
 
-from keg.app import Keg
-
-# silence linter
-current_app
-Keg
+from keg.app import Keg  # noqa: F401
+from keg.component import KegComponent  # noqa: F401

--- a/keg/__init__.py
+++ b/keg/__init__.py
@@ -4,3 +4,5 @@ from flask import current_app  # noqa: F401
 
 from keg.app import Keg  # noqa: F401
 from keg.component import KegComponent  # noqa: F401
+
+__all__ = ['Keg', 'KegComponent', 'current_app']

--- a/keg/__init__.py
+++ b/keg/__init__.py
@@ -3,6 +3,18 @@ from __future__ import absolute_import
 from flask import current_app  # noqa: F401
 
 from keg.app import Keg  # noqa: F401
-from keg.component import KegComponent  # noqa: F401
+from keg.component import (  # noqa: F401
+    KegComponent,
+    KegModelComponent,
+    KegModelViewComponent,
+    KegViewComponent,
+)
 
-__all__ = ['Keg', 'KegComponent', 'current_app']
+__all__ = [
+    'Keg',
+    'KegComponent',
+    'KegModelComponent',
+    'KegModelViewComponent',
+    'KegViewComponent',
+    'current_app',
+]

--- a/keg/app.py
+++ b/keg/app.py
@@ -159,8 +159,7 @@ class Keg(flask.Flask):
         for comp_path in self.config.get('KEG_REGISTERED_COMPONENTS', set()):
             comp_module = importlib.import_module(comp_path)
             comp_object = getattr(comp_module, '__component__')
-            comp_object.set_dotted_path(comp_path)
-            comp_object.init_app(self)
+            comp_object.init_app(self, parent_path=comp_path)
 
     def init_blueprints(self):
         # TODO: probably want to be selective about adding our blueprint

--- a/keg/component.py
+++ b/keg/component.py
@@ -14,75 +14,108 @@ class KegComponent:
     instance of `KegComponent`. E.g. `__component__ = KegComponent('widgets')`
 
     By default, components will load entities from `db_visit_modules` into metadata and register
-    any blueprints specified by `blueprints`.
+    any blueprints specified by `load_blueprints`.
 
-    Blueprints can be created with the helper methods `get_named_blueprint` or `get_blueprint` in
-    order to have a configured template folder relative to the blueprint path.
+    Blueprints can be created with the helper methods `create_named_blueprint` or `create_blueprint`
+    in order to have a configured template folder relative to the blueprint path.
+
+    Use KegModelComponent, KegViewComponent, or KegModelViewComponent for some helpful defaults for
+    model/blueprint discovery.
+
+    db_visit_modules: an iterable of dotted paths (e.g. `.mycomponent.entities`,
+                      `app.component.extraentities`) where Keg can find the entities for this
+                      component to load them into the metadata.
+
+    .. note:: Normally this is not explicitly required but can be useful in cases where imports
+       won't reach that file.
+
+    .. note:: This can accept relative dotted paths (starts with `.`) and it will prepend the
+       component python package determined by Keg when instantiating the component. You can also
+       pass absolute dotted paths and no alterations will be performed.
+
+    load_blueprints: an iterable of tuples, each having a dotted path (e.g. `.mycomponent.views`,
+                     `app.component.extraviews`) and the blueprint attribute name to load and
+                     register on the app. E.g. `(('.views', 'component_bp'), )`
+
+    .. note:: This can accept relative dotted paths (starts with `.`) and it will prepend the
+       component python package determined by Keg when instantiating the component. You can also
+       pass absolute dotted paths and no alterations will be performed.
+
+    template_folder: string to be passed for template config to blueprints created via the component
     """
-    db_visit_modules = ['.model.entities']
-    blueprints = [('.views', 'component_bp')]
+    db_visit_modules = tuple()
+    load_blueprints = tuple()
     template_folder = 'templates'
 
-    def __init__(self, name, app=None, db_visit_modules=None, blueprints=None,
-                 template_folder=None):
+    def __init__(self, name, app=None, db_visit_modules=None, load_blueprints=None,
+                 template_folder=None, parent_path=None):
         self.name = name
-        # This gets used as an absolute parent for the relative import paths of model/blueprints
-        self.relative_dotted_path = ''
         # Allow customization of the defaults in the constructor
         self.db_visit_modules = db_visit_modules or self.db_visit_modules
-        self.blueprints = blueprints or self.blueprints
+        self.load_blueprints = load_blueprints or self.load_blueprints
         self.template_folder = template_folder or self.template_folder
         if app:
             # Not really intended to be used this way, but it fits the flask extension paradigm
             # and could conceivably be set up in lieu of KEG_REGISTERED_COMPONENTS
-            self.init_app(app)
+            self.init_app(app, parent_path=parent_path)
 
-    def set_dotted_path(self, dotted_path):
-        # The Keg app sets this when following KEG_REGISTERED_COMPONENTS
-        self.relative_dotted_path = dotted_path
-
-    def init_app(self, app):
+    def init_app(self, app, parent_path=None):
+        # parent_path gets used as an absolute parent for the relative import paths of
+        # model/blueprints.
+        # E.g. if relative_dotted_path is `my_app.components.widget` and one of the relative import
+        # paths is `.model.entities`, the full import is `my_app.components.widget.model.entities`
         self.init_config(app)
-        self.init_db()
-        self.init_blueprints(app)
+        self.init_db(parent_path)
+        self.init_blueprints(app, parent_path)
 
     def init_config(self, app):
         # Components may define their own config defaults
         pass
 
-    def init_db(self):
+    def init_db(self, parent_path):
         # Intent is to import the listed modules, so their entities are registered in metadata
-        # Note: check the import error, if there is one, so that import errors in the model
-        # modules themselves do not fail silently
         for dotted_path in self.db_visit_modules:
-            import_name = f'{self.relative_dotted_path}{dotted_path}'
-            try:
-                importlib.import_module(import_name)
-            except ModuleNotFoundError as exc:
-                if not import_name.startswith(str(exc).split('\'')[1]):
-                    raise
+            import_name = dotted_path
+            if import_name.startswith('.'):
+                import_name = f'{parent_path}{dotted_path}'
+            importlib.import_module(import_name)
 
-    def init_blueprints(self, app):
-        # Note: check the import error, if there is one, so that import errors in the view
-        # modules themselves do not fail silently
-        for bp_path, bp_attr in self.blueprints:
-            import_name = f'{self.relative_dotted_path}{bp_path}'
-            try:
-                mod_imported = importlib.import_module(import_name)
-            except ModuleNotFoundError as exc:
-                if not import_name.startswith(str(exc).split('\'')[1]):
-                    raise
-            else:
-                if hasattr(mod_imported, bp_attr):
-                    app.register_blueprint(getattr(mod_imported, bp_attr))
+    def init_blueprints(self, app, parent_path):
+        # Register any blueprints that are listed by path in load_blueprints
+        for bp_path, bp_attr in self.load_blueprints:
+            import_name = bp_path
+            if import_name.startswith('.'):
+                import_name = f'{parent_path}{bp_path}'
+            mod_imported = importlib.import_module(import_name)
+            app.register_blueprint(getattr(mod_imported, bp_attr))
 
-    def get_blueprint(self, *args, **kwargs):
-        # Get a flask blueprint having a template folder configured
+    def create_blueprint(self, *args, **kwargs):
+        # Make a flask blueprint having a template folder configured
         kwargs['template_folder'] = kwargs.get('template_folder', self.template_folder)
         bp = flask.Blueprint(*args, **kwargs)
 
         return bp
 
-    def get_named_blueprint(self, *args, **kwargs):
-        # Get a flask blueprint named with the component name, having a template folder configured
-        return self.get_blueprint(self.name, *args, **kwargs)
+    def create_named_blueprint(self, *args, **kwargs):
+        # Make a flask blueprint named with the component name, having a template folder configured
+        return self.create_blueprint(self.name, *args, **kwargs)
+
+
+class ModelMixin:
+    db_visit_modules = ('.model.entities', )
+
+
+class ViewMixin:
+    load_blueprints = (('.views', 'component_bp'), )
+
+
+class KegModelComponent(ModelMixin, KegComponent):
+    pass
+
+
+class KegViewComponent(ViewMixin, KegComponent):
+    pass
+
+
+class KegModelViewComponent(ModelMixin, ViewMixin, KegComponent):
+    pass

--- a/keg/component.py
+++ b/keg/component.py
@@ -1,0 +1,83 @@
+import importlib
+
+import flask
+
+
+class KegComponent:
+    """ Keg components follow the paradigm of flask extensions, and provide some defaults for the
+    purpose of setting up model/view structure. Using components, a project may be broken down into
+    logical blocks, each having their own entities, blueprints, templates, tests, etc.
+
+    Setup involves:
+    - KEG_REGISTERED_COMPONENTS config setting: assumed to be an iterable of importable dotted paths
+    - `__component__`: at the top level of each dotted path, this attribute should point to an
+    instance of `KegComponent`. E.g. `__component__ = KegComponent('widgets')`
+
+    By default, components will load entities from `db_visit_modules` into metadata and register
+    any blueprints specified by `blueprints`.
+
+    Blueprints can be created with the helper methods `get_named_blueprint` or `get_blueprint` in
+    order to have a configured template folder relative to the blueprint path.
+    """
+    db_visit_modules = ['.model.entities']
+    blueprints = [('.views', 'component_bp')]
+    template_folder = 'templates'
+
+    def __init__(self, name, app=None, db_visit_modules=None, blueprints=None,
+                 template_folder=None):
+        self.name = name
+        # This gets used as an absolute parent for the relative import paths of model/blueprints
+        self.relative_dotted_path = ''
+        # Allow customization of the defaults in the constructor
+        self.db_visit_modules = db_visit_modules or self.db_visit_modules
+        self.blueprints = blueprints or self.blueprints
+        self.template_folder = template_folder or self.template_folder
+        if app:
+            # Not really intended to be used this way, but it fits the flask extension paradigm
+            # and could conceivably be set up in lieu of KEG_REGISTERED_COMPONENTS
+            self.init_app(app)
+
+    def set_dotted_path(self, dotted_path):
+        # The Keg app sets this when following KEG_REGISTERED_COMPONENTS
+        self.relative_dotted_path = dotted_path
+
+    def init_app(self, app):
+        self.init_db()
+        self.init_blueprints(app)
+
+    def init_db(self):
+        # Intent is to import the listed modules, so their entities are registered in metadata
+        # Note: check the import error, if there is one, so that import errors in the model
+        # modules themselves do not fail silently
+        for dotted_path in self.db_visit_modules:
+            import_name = f'{self.relative_dotted_path}{dotted_path}'
+            try:
+                importlib.import_module(import_name)
+            except ModuleNotFoundError as exc:
+                if not import_name.startswith(str(exc).split('\'')[1]):
+                    raise
+
+    def init_blueprints(self, app):
+        # Note: check the import error, if there is one, so that import errors in the view
+        # modules themselves do not fail silently
+        for bp_path, bp_attr in self.blueprints:
+            import_name = f'{self.relative_dotted_path}{bp_path}'
+            try:
+                mod_imported = importlib.import_module(import_name)
+            except ModuleNotFoundError as exc:
+                if not import_name.startswith(str(exc).split('\'')[1]):
+                    raise
+            else:
+                if hasattr(mod_imported, bp_attr):
+                    app.register_blueprint(getattr(mod_imported, bp_attr))
+
+    def get_blueprint(self, *args, **kwargs):
+        # Get a flask blueprint having a template folder configured
+        kwargs['template_folder'] = kwargs.get('template_folder', self.template_folder)
+        bp = flask.Blueprint(*args, **kwargs)
+
+        return bp
+
+    def get_named_blueprint(self, *args, **kwargs):
+        # Get a flask blueprint named with the component name, having a template folder configured
+        return self.get_blueprint(self.name, *args, **kwargs)

--- a/keg/component.py
+++ b/keg/component.py
@@ -42,8 +42,13 @@ class KegComponent:
         self.relative_dotted_path = dotted_path
 
     def init_app(self, app):
+        self.init_config(app)
         self.init_db()
         self.init_blueprints(app)
+
+    def init_config(self, app):
+        # Components may define their own config defaults
+        pass
 
     def init_db(self):
         # Intent is to import the listed modules, so their entities are registered in metadata

--- a/keg/tests/test_db.py
+++ b/keg/tests/test_db.py
@@ -7,6 +7,7 @@ from keg.db import db
 from keg.signals import db_init_pre, db_init_post, db_clear_post, db_clear_pre
 from keg.testing import invoke_command
 
+#from keg_apps.db.blog.model.entities import Blog
 import keg_apps.db.model.entities as ents
 from keg_apps.db.app import DBApp
 from keg_apps.db2 import DB2App
@@ -27,11 +28,14 @@ class TestDB(object):
         DBApp.testing_prep()
 
     def test_primary_db_entity(self):
-        assert ents.Blog.query.count() == 0
-        blog = ents.Blog(title=u'foo')
+        # importing Blog here to ensure we're importing after app init, which will only succeed if
+        # the component has loaded properly
+        from keg_apps.db.blog.model.entities import Blog
+        assert Blog.query.count() == 0
+        blog = Blog(title=u'foo')
         db.session.add(blog)
         db.session.commit()
-        assert ents.Blog.query.count() == 1
+        assert Blog.query.count() == 1
 
     def test_postgres_bind_db_entity(self):
         assert ents.PGDud.query.count() == 0
@@ -63,6 +67,10 @@ class TestDatabaseManager(object):
         DBApp.testing_prep()
 
     def test_db_init_with_clear(self):
+        # importing Blog here to ensure we're importing after app init, which will only succeed if
+        # the component has loaded properly
+        from keg_apps.db.blog.model.entities import Blog
+
         # have to use self here to enable the inner functions to adjust an outer-context variable
         self.init_pre_connected = False
         self.init_post_connected = False
@@ -85,8 +93,8 @@ class TestDatabaseManager(object):
         def catch_clear_post(app):
             self.clear_post_connected = True
 
-        ents.Blog.testing_create()
-        assert ents.Blog.query.count() >= 1
+        Blog.testing_create()
+        assert Blog.query.count() >= 1
         ents.PGDud2.testing_create()
         assert ents.PGDud2.query.count() >= 1
 
@@ -95,9 +103,9 @@ class TestDatabaseManager(object):
         # todo: We could check all the intermediate steps, but this is more a functional test
         # for now.  If the record is gone and we can create an new blog post, then we assume the
         # clear and init went ok.
-        assert ents.Blog.query.count() == 0
-        ents.Blog.testing_create()
-        assert ents.Blog.query.count() == 1
+        assert Blog.query.count() == 0
+        Blog.testing_create()
+        assert Blog.query.count() == 1
 
         assert self.init_pre_connected
         assert self.init_post_connected

--- a/keg/tests/test_db.py
+++ b/keg/tests/test_db.py
@@ -7,7 +7,9 @@ from keg.db import db
 from keg.signals import db_init_pre, db_init_post, db_clear_post, db_clear_pre
 from keg.testing import invoke_command
 
-#from keg_apps.db.blog.model.entities import Blog
+# Note: we do not want to import Blog directly here. Doing so will affect metadata collection and
+# prevent the tests below from proving that component initialization is loading the model.
+# from keg_apps.db.blog.model.entities import Blog
 import keg_apps.db.model.entities as ents
 from keg_apps.db.app import DBApp
 from keg_apps.db2 import DB2App

--- a/keg/tests/test_web.py
+++ b/keg/tests/test_web.py
@@ -30,3 +30,11 @@ class TestBlueprintUsage(WebBase):
     def test_blueprint_template_folder(self):
         resp = self.testapp.get('/tanagra/blueprint-test')
         assert 'blueprint template found ok' in resp
+
+
+class TestComponentBlueprint(WebBase):
+    appcls = WebApp
+
+    def test_component_blueprint_loads(self):
+        resp = self.testapp.get('/blog')
+        assert 'I am a blog' in resp

--- a/keg_apps/db/blog/__init__.py
+++ b/keg_apps/db/blog/__init__.py
@@ -1,0 +1,4 @@
+from keg import KegComponent
+
+
+__component__ = KegComponent('blog')

--- a/keg_apps/db/blog/__init__.py
+++ b/keg_apps/db/blog/__init__.py
@@ -1,4 +1,4 @@
-from keg import KegComponent
+from keg import KegModelComponent
 
 
-__component__ = KegComponent('blog')
+__component__ = KegModelComponent('blog')

--- a/keg_apps/db/blog/model/entities.py
+++ b/keg_apps/db/blog/model/entities.py
@@ -1,0 +1,17 @@
+from blazeutils.strings import randchars
+
+from keg.db import db
+
+
+class Blog(db.Model):
+    __tablename__ = 'blogs'
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.Unicode(50), unique=True, nullable=False)
+
+    @classmethod
+    def testing_create(cls):
+        blog = Blog(title=randchars())
+        db.session.add(blog)
+        db.session.commit()
+        return blog

--- a/keg_apps/db/config.py
+++ b/keg_apps/db/config.py
@@ -2,6 +2,10 @@
 class DefaultProfile(object):
     KEG_KEYRING_ENABLE = False
 
+    KEG_REGISTERED_COMPONENTS = {
+        'keg_apps.db.blog',
+    }
+
 
 class TestProfile(object):
     KEG_DB_DIALECT_OPTIONS = {

--- a/keg_apps/db/model/entities.py
+++ b/keg_apps/db/model/entities.py
@@ -3,20 +3,6 @@ from blazeutils.strings import randchars
 from keg.db import db
 
 
-class Blog(db.Model):
-    __tablename__ = 'blogs'
-
-    id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.Unicode(50), unique=True, nullable=False)
-
-    @classmethod
-    def testing_create(cls):
-        blog = Blog(title=randchars())
-        db.session.add(blog)
-        db.session.commit()
-        return blog
-
-
 ####
 # The next several entities exist to facilitate testing of the way Keg handles multiple database
 # binds and dialects.

--- a/keg_apps/web/app.py
+++ b/keg_apps/web/app.py
@@ -13,7 +13,7 @@ def sayfoo():
 
 
 class WebApp(Keg):
-    import_name = __name__
+    import_name = 'keg_apps.web'
     use_blueprints = all_blueprints
     keyring_enabled = False
 

--- a/keg_apps/web/blog/__init__.py
+++ b/keg_apps/web/blog/__init__.py
@@ -1,3 +1,3 @@
-from keg import KegComponent
+from keg import KegViewComponent
 
-__component__ = KegComponent('blog')
+__component__ = KegViewComponent('blog')

--- a/keg_apps/web/blog/__init__.py
+++ b/keg_apps/web/blog/__init__.py
@@ -1,0 +1,3 @@
+from keg import KegComponent
+
+__component__ = KegComponent('blog')

--- a/keg_apps/web/blog/templates/blog.html
+++ b/keg_apps/web/blog/templates/blog.html
@@ -1,0 +1,1 @@
+I am a blog

--- a/keg_apps/web/blog/views.py
+++ b/keg_apps/web/blog/views.py
@@ -1,0 +1,12 @@
+from keg.web import BaseView
+
+from . import __component__
+
+component_bp = __component__.get_named_blueprint(__name__)
+
+
+class Blog(BaseView):
+    blueprint = component_bp
+
+    def get(self):
+        return self.render()

--- a/keg_apps/web/blog/views.py
+++ b/keg_apps/web/blog/views.py
@@ -2,7 +2,7 @@ from keg.web import BaseView
 
 from . import __component__
 
-component_bp = __component__.get_named_blueprint(__name__)
+component_bp = __component__.create_named_blueprint(__name__)
 
 
 class Blog(BaseView):

--- a/keg_apps/web/config.py
+++ b/keg_apps/web/config.py
@@ -1,0 +1,5 @@
+class DefaultProfile(object):
+
+    KEG_REGISTERED_COMPONENTS = {
+        'keg_apps.web.blog',
+    }

--- a/readme.rst
+++ b/readme.rst
@@ -243,30 +243,37 @@ logical blocks, each having their own entities, blueprints, templates, tests, et
 
   * At the top level of the component, `__component__` must be defined as an instance of KegComponent
 
-    * e.g. `__component__ = KegComponent('blog')`
+    * Depending on the needs of the component, model and view discovery may be driven by the subclasses
+      of KegComponent that have path defaults
+    * Examples:
+
+      * `__component__ = KegModelComponent('blog')`
+      * `__component__ = KegViewComponent('blog')`
+      * `__component__ = KegModelViewComponent('blog')`
 
 * Component discovery
 
   * A component will attempt to load model and blueprints on app init
   * The default paths relative to the component may be modified or extended on the component's definition
-
-    * Note, these default paths need not exist for successful app init
-
-  * Model: `.model.entities`
+  * Default model path in "model" components: `.model.entities`
 
     * Override via the component's `db_visit_modules` list of relative import paths
 
-  * Blueprint: `.views.component_bp`
+  * Default blueprint path for "view" components: `.views.component_bp`
 
-    * Use the `get_named_blueprint` or `get_blueprint` helpers on the component's `__component__`
+    * Use the `create_named_blueprint` or `create_blueprint` helpers on the component's `__component__`
       to create blueprints with configured template folders
-    * Override via the component's `blueprints` list
+    * Override via the component's `load_blueprints` list
 
       * List elements are a tuple of the relative import path and the name of the blueprint attribute
 
     * Components have their own template stores, in a `templates` folder
 
       * Override the component's template path via the `template_folder` attribute
+
+  * Paths may also be supplied to the constructor
+
+    * e.g. `__component__ = KegComponent('blog', db_visit_modules=('.somewhere.else', ))`
 
 
 Keg Development

--- a/readme.rst
+++ b/readme.rst
@@ -228,6 +228,47 @@ A view may be given a `url` attribute to override the default:
 See `keg_apps/web/views/routing.py` for other routing possibilities that BaseView supports.
 
 
+Components
+==========
+
+Keg components follow the paradigm of flask extensions, and provide some defaults for the
+purpose of setting up model/view structure. Using components, a project may be broken down into
+logical blocks, each having their own entities, blueprints, templates, tests, etc.
+
+* Components need to be registered in config at `KEG_REGISTERED_COMPONENTS`
+
+  * The path given here should be a full dotted path to the top level of the component
+
+    * e.g. `my_app.components.blog`
+
+  * At the top level of the component, `__component__` must be defined as an instance of KegComponent
+
+    * e.g. `__component__ = KegComponent('blog')`
+
+* Component discovery
+
+  * A component will attempt to load model and blueprints on app init
+  * The default paths relative to the component may be modified or extended on the component's definition
+
+    * Note, these default paths need not exist for successful app init
+
+  * Model: `.model.entities`
+
+    * Override via the component's `db_visit_modules` list of relative import paths
+
+  * Blueprint: `.views.component_bp`
+
+    * Use the `get_named_blueprint` or `get_blueprint` helpers on the component's `__component__`
+      to create blueprints with configured template folders
+    * Override via the component's `blueprints` list
+
+      * List elements are a tuple of the relative import path and the name of the blueprint attribute
+
+    * Components have their own template stores, in a `templates` folder
+
+      * Override the component's template path via the `template_folder` attribute
+
+
 Keg Development
 ===============
 


### PR DESCRIPTION
Provides a clean, framework-supported method of dividing apps into logical components.

- components follow the flask extension paradigm (expects to have `init_app` called)
- components are specified in app config as dotted paths
  - they are not tied to a specific place in the folder structure, or even the app itself necessarily. So, depending on their internal requirements, components should be shareable.
- by default, components will load model into metadata and register blueprints with a template path
- components may also create their own config defaults

fixes #124