### PR TITLE
Add config key to enable foreign keys for SQLite

### DIFF
--- a/keg/tests/test_app.py
+++ b/keg/tests/test_app.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 
+from unittest import mock
+
 import pytest
+import sqlalchemy as sa
 
 from keg.app import Keg, KegAppError
 from keg_apps.cli2.app import CLI2App
+from keg_apps.db2 import DB2App
 
 
 class TestInit(object):
@@ -13,6 +17,18 @@ class TestInit(object):
             app = CLI2App(__name__)
             app.init(use_test_profile=True)
             app.init(use_test_profile=True)
+
+
+class TestSQLitePragma:
+    @mock.patch('keg.app.sa_event', autospec=True, spec_set=True)
+    def test_config_set(self, m_sa_event):
+        DB2App.testing_prep(KEG_SQLITE_ENABLE_FOREIGN_KEYS=True)
+        m_sa_event.listens_for.assert_called_once_with(sa.engine.Engine, 'connect')
+
+    @mock.patch('keg.app.sa_event', autospec=True, spec_set=True)
+    def test_config_not_set(self, m_sa_event):
+        DB2App.testing_prep()
+        m_sa_event.listens_for.assert_not_called()
 
 
 class TestRouteDecorator(object):

--- a/readme.rst
+++ b/readme.rst
@@ -328,3 +328,4 @@ This is not an exhaustive list of `KEG_` specific configuration variables:
           'json_serializer': flask.json.dumps,
           'json_deserializer': flask.json.loads,
       }
+- ``KEG_SQLITE_ENABLE_FOREIGN_KEYS``: Configure SQLite to enforce foreign keys by default


### PR DESCRIPTION
- KEG_SQLITE_ENABLE_FOREIGN_KEYS
- Issues foreign key pragma on connecting

Fixes GH-64
