### PR TITLE
Add dotenv support to CLI from Flask

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # If a branch has a PR, don't build it separately.  Avoids queueing two appveyor runs for the same
 # commit.
 skip_branch_with_pr: true
+image:
+  - Visual Studio 2015
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the

--- a/keg/cli.py
+++ b/keg/cli.py
@@ -12,9 +12,22 @@ from keg import current_app
 from keg.extensions import gettext as _
 
 
+try:
+    import dotenv
+except ImportError:
+    dotenv = None
+
+try:
+    from flask.helpers import get_load_dotenv
+except ImportError:
+    def get_load_dotenv(default=False):
+        return False
+
+
 class KegAppGroup(flask.cli.AppGroup):
-    def __init__(self, create_app, add_default_commands=True, *args, **kwargs):
+    def __init__(self, create_app, add_default_commands=True, load_dotenv=True, *args, **kwargs):
         self.create_app = create_app
+        self.load_dotenv = load_dotenv
 
         flask.cli.AppGroup.__init__(self, *args, **kwargs)
         if add_default_commands:
@@ -51,6 +64,9 @@ class KegAppGroup(flask.cli.AppGroup):
         return click.Group.get_command(self, ctx, name)
 
     def main(self, *args, **kwargs):
+        if get_load_dotenv(self.load_dotenv):
+            flask.cli.load_dotenv()
+
         obj = kwargs.get('obj')
         if obj is None:
             obj = flask.cli.ScriptInfo(create_app=self.create_app)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
             "sqlalchemy_pyodbc_mssql; sys_platform == 'win32'",
             'pytest',
             'pytest-cov',
+            'python-dotenv',
             'psycopg2-binary',
             'mock',
         ],


### PR DESCRIPTION
- Automatically load .flaskenv or .env, if present
- Same implementation as flask/cli.py

Refs level12/keg-app-cookiecutter#101
