### PR TITLE
Create additional postgres schemas on init

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # If a branch has a PR, don't build it separately.  Avoids queueing two appveyor runs for the same
 # commit.
 skip_branch_with_pr: true
+image:
+  - Visual Studio 2015
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the

--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import warnings
 
 import flask_sqlalchemy as fsa
 import sqlalchemy as sa
@@ -131,4 +132,8 @@ class DatabaseManager(object):
     def db_clear(self):
         db_clear_pre.send(self.app)
         self.drop_all()
+        if hasattr(self, 'prep_empty') and callable(self.prep_empty):
+            warnings.warn('prep_empty is deprecated and will not be called in future versions',
+                          DeprecationWarning, 2)
+            self.prep_empty()
         db_clear_post.send(self.app)

--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -109,6 +109,10 @@ class DatabaseManager(object):
     def on_testing_start(self, app):
         self.db_init_with_clear()
 
+    def create_all(self):
+        for dialect in self.all_bind_dialects():
+            dialect.create_all()
+
     def drop_all(self):
         db.session.remove()
         for dialect in self.all_bind_dialects():
@@ -125,7 +129,7 @@ class DatabaseManager(object):
 
     def db_init(self):
         db_init_pre.send(self.app)
-        db.create_all()
+        self.create_all()
         db_init_post.send(self.app)
 
     def db_clear(self):

--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -118,10 +118,6 @@ class DatabaseManager(object):
         for dialect in self.all_bind_dialects():
             dialect.drop_all()
 
-    def prep_empty(self):
-        for dialect in self.all_bind_dialects():
-            dialect.prep_empty()
-
     # The methods that follow will trigger application events.
     def db_init_with_clear(self):
         self.db_clear()
@@ -135,6 +131,4 @@ class DatabaseManager(object):
     def db_clear(self):
         db_clear_pre.send(self.app)
         self.drop_all()
-        # todo: prep_empty() should probably be an event
-        self.prep_empty()
         db_clear_post.send(self.app)

--- a/keg/db/dialect_ops.py
+++ b/keg/db/dialect_ops.py
@@ -54,19 +54,18 @@ class PostgreSQLOps(DialectOperations):
     dialect_name = 'postgresql'
     option_defaults = {'schemas': ('public',)}
 
-    def create_all(self):
+    def create_schemas(self):
         sql = []
         connection_user = self.engine.url.username
         for schema in self.opt_schemas:
-            sql.extend(
-                [
-                    'CREATE SCHEMA IF NOT EXISTS "{}" AUTHORIZATION "{}";'.format(
-                        schema, connection_user
-                    ),
-                    'GRANT ALL ON SCHEMA "{}" TO "{}";'.format(schema, connection_user),
-                ]
-            )
+            sql.extend([
+                f'CREATE SCHEMA IF NOT EXISTS "{schema}" AUTHORIZATION "{connection_user}";',
+                f'GRANT ALL ON SCHEMA "{schema}" TO "{connection_user}";',
+            ])
         self.execute_sql(sql)
+
+    def create_all(self):
+        self.create_schemas()
         super().create_all()
 
     def drop_all(self):
@@ -78,14 +77,7 @@ class PostgreSQLOps(DialectOperations):
         self.execute_sql(sql)
 
     def prep_empty(self):
-        sql = []
-        connection_user = self.engine.url.username
-        for schema in self.opt_schemas:
-            sql.extend([
-                'CREATE SCHEMA "{}" AUTHORIZATION "{}";'.format(schema, connection_user),
-                'GRANT ALL ON SCHEMA "{}" TO "{}";'.format(schema, connection_user),
-            ])
-        self.execute_sql(sql)
+        self.create_schemas()
 
 
 DialectOperations.dialect_map['postgresql'] = PostgreSQLOps

--- a/keg/db/dialect_ops.py
+++ b/keg/db/dialect_ops.py
@@ -54,6 +54,21 @@ class PostgreSQLOps(DialectOperations):
     dialect_name = 'postgresql'
     option_defaults = {'schemas': ('public',)}
 
+    def create_all(self):
+        sql = []
+        connection_user = self.engine.url.username
+        for schema in self.opt_schemas:
+            sql.extend(
+                [
+                    'CREATE SCHEMA IF NOT EXISTS "{}" AUTHORIZATION "{}";'.format(
+                        schema, connection_user
+                    ),
+                    'GRANT ALL ON SCHEMA "{}" TO "{}";'.format(schema, connection_user),
+                ]
+            )
+        self.execute_sql(sql)
+        super().create_all()
+
     def drop_all(self):
         sql = []
         for schema in self.opt_schemas:

--- a/keg/tests/test_db.py
+++ b/keg/tests/test_db.py
@@ -124,7 +124,7 @@ class TestDatabaseManager(object):
             m_warn.assert_called_once_with(
                 'prep_empty is deprecated and will not be called in future versions',
                 DeprecationWarning, 2)
-            
+
             current_app.db_manager.prep_empty = None
             current_app.db_manager.db_init_with_clear()
             assert not m_warn.call_count

--- a/keg/tests/test_db.py
+++ b/keg/tests/test_db.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from unittest import mock
 
 import pytest
 
@@ -113,6 +114,20 @@ class TestDatabaseManager(object):
         assert self.init_post_connected
         assert self.clear_pre_connected
         assert self.clear_post_connected
+
+    def prep_empty_deprecation(self, m_warnings):
+        current_app.db_manager.prep_empty = lambda *args, **kwargs: False
+        current_app.db_manager.db_init_with_clear()
+
+        with mock.patch('keg.db.warnings.warn', autospec=True, spec_set=True) as m_warn:
+            current_app.db_manager.db_init_with_clear()
+            m_warn.assert_called_once_with(
+                'prep_empty is deprecated and will not be called in future versions',
+                DeprecationWarning, 2)
+            
+            current_app.db_manager.prep_empty = None
+            current_app.db_manager.db_init_with_clear()
+            assert not m_warn.call_count
 
 
 class TestKegSQLAlchemy(object):

--- a/keg/tests/test_db_dialects.py
+++ b/keg/tests/test_db_dialects.py
@@ -82,6 +82,27 @@ class TestPostgreSQL(DialectExam):
         self.engine().execute('create view fooschema.vbar as select * from fooschema.bar')
         return 4
 
+    def test_create_all_without_prepping(self):
+        """Test that create_all creates necessary schemas"""
+        self.dialect().drop_all()
+        self.dialect().create_all()
+        assert len(self.obj_names()) == self.entity_count
+
+    def test_create_all_existing_schemas(self):
+        """Test that create_all can be called when schemas already exist"""
+        self.dialect().drop_all()
+        self.dialect().create_all()
+        self.dialect().create_all()
+        assert len(self.obj_names()) == self.entity_count
+
+    def test_prep_all_existing_schemas(self):
+        """Test that prep_all can be called when schemas already exist"""
+        self.dialect().drop_all()
+        self.dialect().prep_empty()
+        self.dialect().create_all()
+        self.dialect().prep_empty()
+        assert len(self.obj_names()) == self.entity_count
+
 
 class TestMicrosoftSQL(DialectExam):
     bind_name = 'mssql'

--- a/keg/tests/test_db_dialects.py
+++ b/keg/tests/test_db_dialects.py
@@ -55,7 +55,6 @@ class DialectExam(object):
 
     def test_create_all(self):
         self.dialect().drop_all()
-        self.dialect().prep_empty()
         self.dialect().create_all()
         assert len(self.obj_names()) == self.entity_count
 
@@ -95,14 +94,6 @@ class TestPostgreSQL(DialectExam):
         self.dialect().create_all()
         assert len(self.obj_names()) == self.entity_count
 
-    def test_prep_all_existing_schemas(self):
-        """Test that prep_all can be called when schemas already exist"""
-        self.dialect().drop_all()
-        self.dialect().prep_empty()
-        self.dialect().create_all()
-        self.dialect().prep_empty()
-        assert len(self.obj_names()) == self.entity_count
-
 
 class TestMicrosoftSQL(DialectExam):
     bind_name = 'mssql'
@@ -123,3 +114,16 @@ class TestMicrosoftSQL(DialectExam):
         self.engine().execute('create table fooschema.bar(label varchar(20))')
         self.engine().execute('create view fooschema.vbar as select * from fooschema.bar')
         return 4
+
+    def test_create_all_without_prepping(self):
+        """Test that create_all creates necessary schemas"""
+        self.dialect().drop_all()
+        self.dialect().create_all()
+        assert len(self.obj_names()) == self.entity_count
+
+    def test_create_all_existing_schemas(self):
+        """Test that create_all can be called when schemas already exist"""
+        self.dialect().drop_all()
+        self.dialect().create_all()
+        self.dialect().create_all()
+        assert len(self.obj_names()) == self.entity_count


### PR DESCRIPTION
Create missing schemas when running `develop db init`

Tested by creating a cookiecutter project and running commands.

Fixes GH-40
