### PR TITLE
resolve flask deprecations

### DIFF
--- a/keg/db/__init__.py
+++ b/keg/db/__init__.py
@@ -33,6 +33,18 @@ class KegSQLAlchemy(fsa.SQLAlchemy):
 
         return super_return_value
 
+    def get_engine(self, app=None, bind=None):
+        if not hasattr(self, '_app_engines'):
+            # older version of flask-sqlalchemy, we can just call super
+            return super().get_engine(app=app, bind=bind)
+        
+        # More recent flask-sqlalchemy, use the cached engines directly.
+        # Note: we don't necessarily have an app context active here, depending
+        # on if this is being called during app init. But if we attempt to access
+        # the underlying cache directly, we get a weak ref error.
+        with app.app_context():
+            return self.engines[bind]
+
     def get_engines(self, app):
         # the default engine doesn't have a bind
         retval = [(None, self.get_engine(app))]

--- a/keg/db/dialect_ops.py
+++ b/keg/db/dialect_ops.py
@@ -32,7 +32,7 @@ class DialectOperations(object):
 
     def create_all(self):
         self.create_schemas()
-        db.create_all(bind=self.bind_name)
+        db.create_all(self.bind_name)
 
     def create_schemas(self):
         pass

--- a/keg/testing.py
+++ b/keg/testing.py
@@ -171,9 +171,17 @@ def invoke_command(app_cls, *args, **kwargs):
 
 
 def cleanup_app_contexts():
-    while flask.current_app or False:
+    while flask.current_app:
         cm = ContextManager.get_for(flask.current_app.__class__)
-        cm.cleanup()
+        if cm.ctx:
+            cm.cleanup()
+        else:
+            break
+
+    # support older flask as well
+    if flask.current_app and getattr(flask, '_app_ctx_stack'):
+        while flask._app_ctx_stack.pop():
+            pass
 
 
 class CLIBase(object):

--- a/keg/testing.py
+++ b/keg/testing.py
@@ -170,6 +170,12 @@ def invoke_command(app_cls, *args, **kwargs):
     return result
 
 
+def cleanup_app_contexts():
+    while flask.current_app or False:
+        cm = ContextManager.get_for(flask.current_app.__class__)
+        cm.cleanup()
+
+
 class CLIBase(object):
     """Test class base for testing Keg click commands.
 
@@ -186,6 +192,10 @@ class CLIBase(object):
 
     @classmethod
     def setup_class(cls):
+        # If a current app context is set, it may complicate what click is doing to
+        # set up and run a specific app.
+        cleanup_app_contexts()
+
         cls.runner = click.testing.CliRunner()
 
     def invoke(self, *args, **kwargs):

--- a/keg/tests/test_cli.py
+++ b/keg/tests/test_cli.py
@@ -40,9 +40,12 @@ class TestCLI(CLIBase):
     @need_dotenv
     def test_dotenv(self):
         test_dir = os.path.dirname(__file__)
+        # ensure flask looks in the expected working directory
+        working_dir = os.path.abspath(os.path.join(test_dir, '..', '..'))
+        os.chdir(working_dir)
 
         # Place dotenv file in search path of python-dotenv
-        flaskenv = os.path.abspath(os.path.join(test_dir, '..', '..', '.flaskenv'))
+        flaskenv = os.path.join(working_dir, '.flaskenv')
         try:
             with open(flaskenv, 'w') as f:
                 f.write('FOO=bar')
@@ -57,9 +60,12 @@ class TestCLI(CLIBase):
     @mock.patch.dict(os.environ, {'FLASK_SKIP_DOTENV': '1'})
     def test_disable_dotenv_from_env(self):
         test_dir = os.path.dirname(__file__)
+        # ensure flask looks in the expected working directory
+        working_dir = os.path.abspath(os.path.join(test_dir, '..', '..'))
+        os.chdir(working_dir)
 
         # Place dotenv file in search path of python-dotenv
-        flaskenv = os.path.abspath(os.path.join(test_dir, '..', '..', '.flaskenv'))
+        flaskenv = os.path.join(working_dir, '.flaskenv')
         try:
             with open(flaskenv, 'w') as f:
                 f.write('FOO=bar')

--- a/keg/tests/test_config.py
+++ b/keg/tests/test_config.py
@@ -6,7 +6,7 @@ import mock
 
 from keg.app import Keg
 from keg.config import Config
-from keg.testing import invoke_command
+from keg.testing import cleanup_app_contexts, invoke_command
 from keg_apps.profile.cli import ProfileApp
 
 
@@ -137,6 +137,7 @@ class TestProfileLoading(object):
         """
             Using testing.invoke_command() should use a testing profile by default.
         """
+        cleanup_app_contexts()
         resp = invoke_command(ProfileApp, 'show-profile')
         assert 'testing-default' in resp.output
 
@@ -144,6 +145,7 @@ class TestProfileLoading(object):
         """
             Environement overrides should still take priority for invoke_command() usage.
         """
+        cleanup_app_contexts()
         resp = invoke_command(ProfileApp, 'show-profile',
                               env={'KEG_APPS_PROFILE_CONFIG_PROFILE': 'EnvironmentProfile'})
         assert 'environment' in resp.output

--- a/keg/tests/test_db.py
+++ b/keg/tests/test_db.py
@@ -61,7 +61,10 @@ class TestDB2(object):
         # Make sure we don't get an error initializing the app when the SQLALCHEMY_BINDS config
         # option is None
         app = DB2App.testing_prep()
-        assert app.config.get('SQLALCHEMY_BINDS') is None
+        value = app.config.get('SQLALCHEMY_BINDS')
+        # flask-sqlalchemy < 3.0: None
+        # flask-sqlalchemy 3.0+: {}
+        assert value is None or value == {}
 
 
 class TestDatabaseManager(object):

--- a/keg/web.py
+++ b/keg/web.py
@@ -8,9 +8,9 @@ import flask
 from flask import request
 from flask.views import MethodView, http_method_funcs
 try:
-   from flask.views import MethodViewType
+    from flask.views import MethodViewType
 except ImportError:
-   MethodViewType = None
+    MethodViewType = None
 import six
 from werkzeug.datastructures import MultiDict
 
@@ -123,7 +123,7 @@ class BaseView(MethodView, metaclass=_ViewMeta):
         changed to using `init_subclass`. If the old way is enabled, no need to
         do anything but call the super here."""
         super().__init_subclass__(**kwargs)
-        
+
         if MethodViewType is None and cls.blueprint is not None:
             cls.assign_blueprint(cls.blueprint)
 

--- a/keg/web.py
+++ b/keg/web.py
@@ -6,7 +6,11 @@ import sys
 from blazeutils.strings import case_cw2us, case_cw2dash
 import flask
 from flask import request
-from flask.views import MethodView, MethodViewType, http_method_funcs
+from flask.views import MethodView, http_method_funcs
+try:
+   from flask.views import MethodViewType
+except ImportError:
+   MethodViewType = None
 import six
 from werkzeug.datastructures import MultiDict
 
@@ -82,7 +86,7 @@ def _call_with_expected_args(view, calling_args, method, method_is_bound=True):
     return method(*args, **kwargs)
 
 
-class _ViewMeta(MethodViewType):
+class _OldViewMeta(MethodViewType or object):
     def __init__(cls, name, bases, d):
         MethodViewType.__init__(cls, name, bases, d)
 
@@ -92,6 +96,9 @@ class _ViewMeta(MethodViewType):
         # the view is intended to receive routes.
         if cls.blueprint is not None:
             cls.assign_blueprint(cls.blueprint)
+
+
+_ViewMeta = _OldViewMeta if MethodViewType is not None else type
 
 
 class BaseView(MethodView, metaclass=_ViewMeta):
@@ -110,6 +117,15 @@ class BaseView(MethodView, metaclass=_ViewMeta):
     auto_assign = tuple()
     # names of qs arguments that should be merged w/ URL arguments and passed to view methods
     expected_qs_args = []
+
+    def __init_subclass__(cls, **kwargs):
+        """Flask before 2.2.0 used a metaclass to perform view setup, but this
+        changed to using `init_subclass`. If the old way is enabled, no need to
+        do anything but call the super here."""
+        super().__init_subclass__(**kwargs)
+        
+        if MethodViewType is None and cls.blueprint is not None:
+            cls.assign_blueprint(cls.blueprint)
 
     def __init__(self, responding_method=None):
         self.responding_method = responding_method

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ skip_install = true
 recreate=True
 commands =
     pip --version
-    lowest: pip install flask<2
+    lowest: pip install flask<2 markupsafe~=2.0.0
     pip install --progress-bar off .[tests]
     i18n: pip install --progress-bar off .[i18n]
     # Output installed versions to compare with previous test runs in case a dependency's change


### PR DESCRIPTION
Deprecations/removals resolved:
- Flask 2.2 removes `MethodViewType`, now uses `__init_subclass__` instead of the metaclass
- Flask 2.3 will remove the old (now deprecated) way of fetching the request context from globals
- Flask-SQLAlchemy 3.0 changes several things about setting up and accessing database connections
  - engines are created/cached in `init_app`
  - `create_all` bind kwarg renamed
  - `apply_driver_hacks` renamed

Also had some test suite breakage around how app context was taken down following CLI command invocations. The `current_app` context would still point to the previous instance.

fixes #158 
fixes #183
fixes #184