### PR TITLE
**BC BREAK** no longer add default route when at least one rule present

### DIFF
--- a/docs/source/readme/installation.rst
+++ b/docs/source/readme/installation.rst
@@ -21,5 +21,6 @@ breaking changes. This list should provide information on needed app changes.
     
     - All of an app's routes may be shown on CLI with the ``<app> develop routes`` command
 
+  - Removed ``keg`` blueprint along with ``ping`` and ``exception-test`` routes
   - DB manager ``prep_empty`` method no longer called (had been deprecated)
   - Python 2 support removed

--- a/docs/source/readme/installation.rst
+++ b/docs/source/readme/installation.rst
@@ -2,3 +2,22 @@ Installation
 ============
 
 ``pip install keg``
+
+
+Upgrade Notes
+=============
+
+While we attempt to preserve backward compatibility, some Keg versions doe introduce
+breaking changes. This list should provide information on needed app changes.
+
+- 0.10.0
+  - ``rule``: default class view route no longer generated when any rules are present
+
+    - Absolute route had been provided automatically from the class name, but in some situations
+    this would not be desired. Views that still need that route can use a couple of solutions:
+
+      - Provide an absolute route rule: ``rule('/my-route')``
+      - Use an empty relative route rule: ``rule()``
+
+  - DB manager ``prep_empty`` method no longer called (had been deprecated)
+  - Python 2 support removed

--- a/docs/source/readme/installation.rst
+++ b/docs/source/readme/installation.rst
@@ -7,7 +7,7 @@ Installation
 Upgrade Notes
 =============
 
-While we attempt to preserve backward compatibility, some Keg versions doe introduce
+While we attempt to preserve backward compatibility, some Keg versions do introduce
 breaking changes. This list should provide information on needed app changes.
 
 - 0.10.0
@@ -18,6 +18,8 @@ breaking changes. This list should provide information on needed app changes.
 
       - Provide an absolute route rule: ``rule('/my-route')``
       - Use an empty relative route rule: ``rule()``
+    
+    - All of an app's routes may be shown on CLI with the ``<app> develop routes`` command
 
   - DB manager ``prep_empty`` method no longer called (had been deprecated)
   - Python 2 support removed

--- a/keg/tests/test_view_routing.py
+++ b/keg/tests/test_view_routing.py
@@ -54,6 +54,7 @@ class TestViewRouting(WebBase):
             'routing.cars:list',
             'routing.explicit-route',
             'routing.hello-req',
+            'routing.hello-req2',
             'routing.hello-world',
             'routing.hw-rule-default',
             'routing.misc',
@@ -209,6 +210,20 @@ class TestViewRouting(WebBase):
         assert rule.rule == '/hello-req/<name>'
         assert rule.methods == {'GET', 'HEAD', 'OPTIONS'}
         assert rule.endpoint == 'routing.hello-req'
+
+    def test_route_no_absolute_single_endpoint(self):
+        self.testapp.get('/hello-req2', status=404)
+
+        resp = self.testapp.get('/hello-req2/foo')
+        assert resp.text == 'Hello foo'
+
+        rules = list(self.app.url_map.iter_rules(endpoint='routing.hello-req2'))
+        assert len(rules) == 1
+        rule = rules.pop()
+
+        assert rule.rule == '/hello-req2/<name>'
+        assert rule.methods == {'GET', 'HEAD', 'OPTIONS'}
+        assert rule.endpoint == 'routing.hello-req2'
 
     def test_route_plain(self):
         resp = self.testapp.get('/cars/list')

--- a/keg/web.py
+++ b/keg/web.py
@@ -316,7 +316,7 @@ class BaseView(MethodView, metaclass=_ViewMeta):
             view_func = cls.as_view(str_endpoint)
 
             for rule, options in rules:
-                if rule.startswith('/'):
+                if rule and rule.startswith('/'):
                     class_url = rule
                 elif not rule:
                     rule = class_url

--- a/keg/web.py
+++ b/keg/web.py
@@ -315,16 +315,16 @@ class BaseView(MethodView, metaclass=_ViewMeta):
             str_endpoint = str(endpoint)
             view_func = cls.as_view(str_endpoint)
 
-            absolute_found = False
             for rule, options in rules:
                 if rule.startswith('/'):
-                    absolute_found = True
                     class_url = rule
+                elif not rule:
+                    rule = class_url
                 else:
                     rule = '{}/{}'.format(class_url, rule)
                 cls.blueprint.add_url_rule(rule, endpoint=endpoint, view_func=view_func, **options)
 
-            if not absolute_found:
+            if not rules:
                 cls.blueprint.add_url_rule(class_url, endpoint=endpoint, view_func=view_func)
 
         for rule, options in cls.url_rules:

--- a/keg_apps/web/views/routing.py
+++ b/keg_apps/web/views/routing.py
@@ -63,7 +63,7 @@ class HelloWorld(BaseView):
         /hello-world -> 'Hello World'
         /hello-world/foo -> 'Hello Foo'
     """
-    rule('')
+    rule()
     rule('<name>')
 
     def get(self, name='World'):

--- a/keg_apps/web/views/routing.py
+++ b/keg_apps/web/views/routing.py
@@ -60,10 +60,10 @@ class ExplicitRouteAlt(KegBaseView):
 
 class HelloWorld(BaseView):
     """
-        /hello -> 'Hello World'
-        /hello/foo -> 'Hello Foo'
+        /hello-world -> 'Hello World'
+        /hello-world/foo -> 'Hello Foo'
     """
-    # relative URL indicates this route should be appended to the default rule for the class
+    rule('')
     rule('<name>')
 
     def get(self, name='World'):
@@ -96,6 +96,18 @@ class HelloReq(BaseView):
     """
     # making the rule absolute disables the default rule that would have been created by the class.
     rule('/hello-req/<name>')
+
+    def get(self, name):
+        return _('Hello {name}', name=name)
+
+
+class HelloReq2(BaseView):
+    """
+        /hello-req2 -> 404
+        /hello-req2/foo -> 'Hello Foo'
+    """
+    # no absolute rule, but only one endpoint to use
+    rule('<name>')
 
     def get(self, name):
         return _('Hello {name}', name=name)


### PR DESCRIPTION
Previously, if we had a view like:
```
class MyView(BaseView):
    blueprint = public_bp
    rule('<name>')

    def get(self, name):
        return name
```
We would end up with a couple of routes generated:
- `/my-view/<name>`: corresponds to the given rule
- `/my-view`: default "absolute" route rule provided for the class, even though it doesn't do anything for us in this case

That default route has been useful in two situations:
```
# Example 1
class HelloWorld(BaseView):
    blueprint = public_bp

    def get(self):
        return 'Hello World'

# Example 2
class NameOrDefault(BaseView):
    blueprint = public_bp
    rule('<name>')

    def get(self, name='Charlie Brown'):
        return name
```

In example 1 (HelloWorld), we just have verb-based routes and no explicit rules, so it makes sense to create a default route based on the class name. This PR does not change that behavior.

In example 2 (NameOrDefault), it's very similar to MyView above, but with a default kwarg value if `<name>` isn't provided. Keg would put a route in for that case, and the only way to turn that off would be to supply an absolute route rule (one starting with `/`). I.e. even with explicit route rules provided, an implicit action was still happening to generate the default class route.
- That behavior changes with this PR. Providing any rules at all will turn off the default route generation and assume the developer wants complete control over that process.
- If we really want the default route for a view like `NameOrDefault`, we would need to put an absolute route rule (`rule('/name-or-default')` or a blank rule that would build relative to the class name (`rule()`).

fixes #179